### PR TITLE
fix: redirect to dashboard after connection

### DIFF
--- a/packages/documentation-portal/src/app/(public)/sign/page.tsx
+++ b/packages/documentation-portal/src/app/(public)/sign/page.tsx
@@ -3,9 +3,12 @@ import { currentUser } from '@clerk/nextjs/server'
 import { SignUpButton, SignInButton } from '@clerk/nextjs'
 import { Button } from '@/components/ui/button'
 import Typography from '@/components/atoms/typography'
+import { redirect } from 'next/navigation'
 
 export default async function SignLayout() {
   const user = await currentUser()
+
+  if (user) redirect('/dashboard')
 
   return (
     <div className="flex flex-col items-stretch text-center gap-5 max-w-xs">
@@ -14,10 +17,10 @@ export default async function SignLayout() {
         Notice that only people who receive an access can sign up.
       </Typography>
       <Button size="lg" variant="default">
-        <SignInButton fallbackRedirectUrl="/dashboard">Sign in</SignInButton>
+        <SignInButton>Sign in</SignInButton>
       </Button>
       <Button size="lg" variant="default">
-        <SignUpButton fallbackRedirectUrl="/dashboard">Sign Up</SignUpButton>
+        <SignUpButton>Sign Up</SignUpButton>
       </Button>
     </div>
   )


### PR DESCRIPTION
In order to force redirecting the user to the dashboard, I use a environment variable since it seems it was the only way: https://stackoverflow.com/questions/76309485/clerk-redirecting-to-localhost-after-authentication